### PR TITLE
Fixed sorting of categories

### DIFF
--- a/Config.lua
+++ b/Config.lua
@@ -6,6 +6,15 @@ local tostring = tostring
 local profile = {}
 local popUpSemaphore = false
 
+local function indexOf(array, value)
+    for i, v in ipairs(array) do
+        if v == value then
+            return i
+        end
+    end
+    return nil
+end
+
 StaticPopupDialogs["VRA_IMPORT"] = {
 	text = L["Insert import string"],
 	button1 = L["Import"],
@@ -63,8 +72,9 @@ local function createOptionsForClass(class)
 	if (spellList ~= nil) then
 		for spellID, v in pairs(spellList) do
 			args[v.type] = args[v.type] or {
-				name = addon.PRIORITY[v.type],
+				name = addon.CATEGORY[v.type],
 				type = 'group',
+				order = indexOf(addon.PRIORITY,v.type),
 				inline = true,
 				args = {}
 			}

--- a/Config.lua
+++ b/Config.lua
@@ -74,7 +74,7 @@ local function createOptionsForClass(class)
 			args[v.type] = args[v.type] or {
 				name = addon.CATEGORY[v.type],
 				type = 'group',
-				order = indexOf(addon.PRIORITY,v.type),
+				order = indexOf(addon.CATEGORY_SORT_ORDER,v.type),
 				inline = true,
 				args = {}
 			}

--- a/Constants.lua
+++ b/Constants.lua
@@ -146,10 +146,29 @@ addon.ZONES = {
 }
 
 addon.PRIORITY = {
+	"covenant",
+	"racial",
+	"trinket",
+	"pvptrinket",
+	"interrupt",
+	"dispel",
+	"cc",
+	"disarm",
+	"immunity",
+	"externalDefensive",
+	"defensive",
+	"raidDefensive",
+	"offensive",
+	"counterCC",
+	"raidMovement",
+	"other"
+}
+
+addon.CATEGORY = {
+	["covenant"] = L["Covenant"],
 	["pvptrinket"] = L["PvP Trinket"],
 	["racial"] = L["Racial Traits"],
 	["trinket"] = INVTYPE_TRINKET,
-	["covenant"] = L["Covenant"],
 	["interrupt"] = LOC_TYPE_INTERRUPT,
 	["dispel"] = DISPELS,
 	["cc"] = L["Crowd Control"],

--- a/Constants.lua
+++ b/Constants.lua
@@ -165,10 +165,10 @@ addon.PRIORITY = {
 }
 
 addon.CATEGORY = {
-	["covenant"] = L["Covenant"],
 	["pvptrinket"] = L["PvP Trinket"],
 	["racial"] = L["Racial Traits"],
 	["trinket"] = INVTYPE_TRINKET,
+	["covenant"] = L["Covenant"],
 	["interrupt"] = LOC_TYPE_INTERRUPT,
 	["dispel"] = DISPELS,
 	["cc"] = L["Crowd Control"],

--- a/Constants.lua
+++ b/Constants.lua
@@ -148,19 +148,19 @@ addon.ZONES = {
 addon.PRIORITY = {
 	"covenant",
 	"racial",
-	"trinket",
-	"pvptrinket",
 	"interrupt",
-	"dispel",
-	"cc",
-	"disarm",
-	"immunity",
+	"raidDefensive",
 	"externalDefensive",
 	"defensive",
-	"raidDefensive",
+	"immunity",
 	"offensive",
+	"dispel",
+	"cc",
 	"counterCC",
+	"disarm",
 	"raidMovement",
+	"trinket",
+	"pvptrinket",
 	"other"
 }
 

--- a/Constants.lua
+++ b/Constants.lua
@@ -145,7 +145,7 @@ addon.ZONES = {
 	}
 }
 
-addon.PRIORITY = {
+addon.CATEGORY_SORT_ORDER = {
 	"covenant",
 	"racial",
 	"interrupt",


### PR DESCRIPTION
Old PRIORITY was not sorting categories as they were implemented in a Hash table. Renamed old PRIORITY to CATEGORY as the table serves the purpose of translating from internal category name to external category name