### PR TITLE
check if profile actually has spells configured

### DIFF
--- a/VRA_EN_Julie/VRA_EN_Julie.toc
+++ b/VRA_EN_Julie/VRA_EN_Julie.toc
@@ -6,7 +6,7 @@
 ## Dependencies: VocalRaidAssistant
 ## Author: The VRA Team
 ## IconTexture: Interface\AddOns\VocalRaidAssistant\Media\VOICECHAT-SPEAKER.blp
-## Version: 3.4.2
+## Version: 3.4.3
 
 VRA_EN_Julie.lua
 

--- a/VocalRaidAssistant.lua
+++ b/VocalRaidAssistant.lua
@@ -76,10 +76,12 @@ local function ConfigCleanup(db)
 			end
 			-- Remove invalid spells
 			for zone, _ in pairs(addon.ZONES) do
-				for spellID, _ in pairs(profile.general.area[zone].spells) do
-					if not addon:IsSpellSupported(tonumber(spellID)) then
-						profile.general.area[zone].spells[spellID] = nil
-						addon:prettyPrint(format("Removed unsupported spell %s from config", spellID))
+				if profile.general and profile.general.area[zone] and profile.general.area[zone].spells then
+					for spellID, _ in pairs(profile.general.area[zone].spells) do
+						if not addon:IsSpellSupported(tonumber(spellID)) then
+							profile.general.area[zone].spells[spellID] = nil
+							addon:prettyPrint(format("Removed unsupported spell %s from config", spellID))
+						end
 					end
 				end
 			end

--- a/VocalRaidAssistant.toc
+++ b/VocalRaidAssistant.toc
@@ -6,7 +6,7 @@
 ## Author: Nitrak
 ## IconTexture: Interface\AddOns\VocalRaidAssistant\Media\VOICECHAT-SPEAKER.blp
 ## SavedVariables: VocalRaidAssistantDB
-## Version: 3.4.2
+## Version: 3.4.3
 ## X-Curse-Project-ID: 83086
 ## X-WoWI-ID: 22983
 ## X-Wago-ID: kRNLr8Ko

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Vocal Raid Assistant
 
+## 3.4.3
+- Fixed a bug that could cause the profile to be reset
+
 ## 3.4.2
 - Fix config cleanup routine
 - Fix DH Meta


### PR DESCRIPTION
Some profiles can have no general settings.
This will cause an error, which leads to ResetDB() beeing called.